### PR TITLE
Fix: Resolve PostgreSQL prepared statement conflicts

### DIFF
--- a/lib/shared/prisma.ts
+++ b/lib/shared/prisma.ts
@@ -17,8 +17,14 @@ const createPrismaClient = () => {
     })
   }
   
-  // Use default configuration for other environments
-  return new PrismaClient()
+  // Use non-pooling connection for production to avoid prepared statement conflicts
+  return new PrismaClient({
+    datasources: {
+      db: {
+        url: process.env.POSTGRES_URL_NON_POOLING || process.env.DATABASE_URL
+      }
+    }
+  })
 }
 
 export const prisma = globalForPrisma.prisma ?? createPrismaClient()


### PR DESCRIPTION
- Use non-pooling connection for production environment
- Prevents "prepared statement 's1' already exists" errors
- Fallback to DATABASE_URL if POSTGRES_URL_NON_POOLING not available

🤖 Generated with [Claude Code](https://claude.ai/code)